### PR TITLE
회원 엔티티와 게시글, 댓글의 연관관계 적용

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 
 @Getter
-@ToString
+@ToString(callSuper = true) //AuditingFields 에 있는 것도 ToString 가능하게
 @Table(indexes = {
         @Index(columnList = "title"),
         @Index(columnList = "hashtag"),
@@ -21,13 +21,19 @@ import java.util.Set;
 //@EntityListeners(AuditingEntityListener.class) -> Auditing 할 컬럼을 옮긴 MappedSuperClass 쪽에 지정
 @Entity
 public class Article extends AuditingFields {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Setter
+    @ManyToOne(optional = false) // 필수 엔티티
+    private UserAccount userAccount;
+
+    @Setter
     @Column(nullable = false)
     private String title; // 제목
+
     @Setter
     @Column(nullable = false, length = 10000)
     private String content; // 내용
@@ -36,9 +42,9 @@ public class Article extends AuditingFields {
 //    @Column 옵션 없을 시 생략 가능
     private String hashtag; // 해시태그
 
-    @OrderBy("id")
-    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     @ToString.Exclude /*-> circular referential 발생 방지*/
+    @OrderBy("createdAt DESC")
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private final Set<ArticleComment> articleComments = new LinkedHashSet<>();
 
 
@@ -60,15 +66,16 @@ public class Article extends AuditingFields {
     protected Article() {
     }
 
-    private Article(String title, String content, String hashtag) {
+    private Article(UserAccount userAccount, String title, String content, String hashtag) {
+        this.userAccount = userAccount;
         this.title = title;
         this.content = content;
         this.hashtag = hashtag;
     }
 
     // Factory method
-    public static Article of(String title, String content, String hashtag) {
-        return new Article(title, content, hashtag);
+    public static Article of(UserAccount userAccount, String title, String content, String hashtag) {
+        return new Article(userAccount, title, content, hashtag);
     }
 
     @Override

--- a/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 
 // @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@ToString
+@ToString(callSuper = true) //AuditingFields 에 있는 것도 ToString 가능하게
 @Table(indexes = {
         @Index(columnList = "content"),
         @Index(columnList = "createdAt"),
@@ -25,6 +25,9 @@ public class ArticleComment extends AuditingFields {
     @ManyToOne(optional = false/*,cascade = none -> default*/)
     private Article article; //게시글 (ID)
 
+    @Setter
+    @ManyToOne(optional = false)
+    private UserAccount userAccount;
 
     @Setter
     @Column(nullable = false, length = 500)
@@ -34,13 +37,14 @@ public class ArticleComment extends AuditingFields {
     protected ArticleComment() {
     }
 
-    private ArticleComment(Article article, String content) {
+    private ArticleComment(Article article, UserAccount userAccount, String content) {
         this.article = article;
+        this.userAccount = userAccount;
         this.content = content;
     }
 
-    public static ArticleComment of(Article article, String content) {
-        return new ArticleComment(article, content);
+    public static ArticleComment of(Article article, UserAccount userAccount, String content) {
+        return new ArticleComment(article, userAccount, content);
     }
 
     @Override

--- a/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
@@ -2,6 +2,7 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.config.JpaConfig;
 import com.fastcampus.projectboard.domain.Article;
+import com.fastcampus.projectboard.domain.UserAccount;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,13 +25,16 @@ class JpaRepositoryTest {
 
     private final ArticleRepository articleRepository;
     private final ArticleCommentRepository articleCommentRepository;
+    private final UserAccountRepository userAccountRepository;
 
     public JpaRepositoryTest(
             @Autowired ArticleRepository articleRepository,
-            @Autowired ArticleCommentRepository articleCommentRepository
+            @Autowired ArticleCommentRepository articleCommentRepository,
+            @Autowired UserAccountRepository userAccountRepository
     ) {
         this.articleRepository = articleRepository;
         this.articleCommentRepository = articleCommentRepository;
+        this.userAccountRepository = userAccountRepository;
     }
 
     @DisplayName("select 테스트")
@@ -53,10 +57,13 @@ class JpaRepositoryTest {
     void givenTestData_whenInserting_thenWorksFine() {
         //Given
         long prevCntOfArticles = articleRepository.count();
-        Article article = Article.of("new article", "new content", "#spring");
+        UserAccount userAccount = userAccountRepository.save(
+                UserAccount.of("twonezero", "asdf1234", null, null, null)
+        );
+        Article article = Article.of(userAccount, "new Article", "new content", "#spring");
 
         //When
-        Article savedArticle = articleRepository.save(article);
+        articleRepository.save(article);
 
         //Then
         assertThat(articleRepository.count())


### PR DESCRIPTION
* `data.sql` 테스트 데이터도 모두 업데이트 (이전 커밋에서 시행함 - `d38702`)
* 게시글 -> 댓글 컬렉션의 정렬을 최신 순으로 적용 `createdAt DESC`

This closes #22 