### PR TITLE
게시판 페이징 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -5,7 +5,9 @@ import com.fastcampus.projectboard.domain.type.SearchType;
 import com.fastcampus.projectboard.dto.response.ArticleResponse;
 import com.fastcampus.projectboard.dto.response.ArticleWithCommentsResponse;
 import com.fastcampus.projectboard.service.ArticleService;
+import com.fastcampus.projectboard.service.PaginationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
+
 
 @RequiredArgsConstructor
 @RequestMapping("/articles")
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class ArticleController {
 
     private final ArticleService articleService;
+    private final PaginationService paginationService;
 
     @GetMapping
     public String articles(
@@ -31,14 +36,16 @@ public class ArticleController {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             ModelMap map
     ) {
-
-        map.addAttribute("articles", articleService.searchArticles(searchType,searchValue,pageable).map(ArticleResponse::from));
+        Page<ArticleResponse> articles = articleService.searchArticles(searchType, searchValue, pageable).map(ArticleResponse::from);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+        map.addAttribute("articles", articles);
+        map.addAttribute("paginationBarNumbers", barNumbers);
         return "articles/index";
     }
 
     @GetMapping("/{articleId}")
     public String articles(@PathVariable Long articleId, ModelMap map) {
-        ArticleWithCommentsResponse article =  ArticleWithCommentsResponse.from(articleService.getArticle(articleId));
+        ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticle(articleId));
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
         return "articles/detail";

--- a/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -40,6 +40,7 @@ public class ArticleController {
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("totalCount", articleService.getArticleCount());
         return "articles/index";
     }
 

--- a/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -40,7 +40,7 @@ public class ArticleController {
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
-        map.addAttribute("totalCount", articleService.getArticleCount());
+
         return "articles/index";
     }
 
@@ -49,6 +49,7 @@ public class ArticleController {
         ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticle(articleId));
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
+        map.addAttribute("totalCount", articleService.getArticleCount());
         return "articles/detail";
     }
 

--- a/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
+++ b/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
@@ -72,4 +72,5 @@ public class ArticleService {
     public void deleteArticle(long articleId) {
         articleRepository.deleteById(articleId);
     }
+    public long getArticleCount() {return articleRepository.count();}
 }

--- a/src/main/java/com/fastcampus/projectboard/service/PaginationService.java
+++ b/src/main/java/com/fastcampus/projectboard/service/PaginationService.java
@@ -1,0 +1,23 @@
+package com.fastcampus.projectboard.service;
+
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+public class PaginationService {
+
+    private final static int BAR_LENGTH = 5;
+
+    public List<Integer> getPaginationBarNumbers(int curPageNumber, int totalPages) {
+        int startNumber = Math.max(curPageNumber - (BAR_LENGTH / 2) , 0);
+        int endNumber = Math.min(startNumber + BAR_LENGTH , totalPages) ;
+        return IntStream.range(startNumber, endNumber).boxed().toList();
+    }
+
+    public int curBarLength() {
+        return BAR_LENGTH;
+    }
+}

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -33,7 +33,7 @@
         </section>
 
         <article id="article-content" class="col-md-7 col-lg-8">
-            <pre>본문<br><br></pre>
+            <pre>본문</pre>
         </article>
     </div>
 
@@ -77,7 +77,7 @@
     </div>
 
     <div class="row g-5">
-        <nav aria-label="Page navigation example">
+        <nav id="pagination" aria-label="Page navigation">
             <ul class="pagination">
                 <li class="page-item">
                     <a class="page-link" href="#" aria-label="Previous">

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -19,4 +19,16 @@
             <attr sel="div/p" th:text="${articleComment.content}" />
         </attr>
     </attr>
+
+    <attr sel="#pagination">
+        <attr sel="ul">
+            <attr sel="li[0]/a"
+                  th:href="*{id} - 1 <= 0 ? '#' : |/articles/*{id - 1}|"
+                  th:class="'page-link' + (*{id} - 1 <= 0 ? ' disabled' : '')" />
+            <attr sel="li[1]/a"
+                  th:href="*{id} + 1 > ${totalCount} ? '#' : |/articles/*{id + 1}|"
+                  th:class="'page-link' + (*{id} + 1 > ${totalCount} ? ' disabled' : '')"
+            />
+        </attr>
+    </attr>
 </thlogic>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -86,7 +86,7 @@
         </tbody>
     </table>
 
-    <nav id="pagination" aria-label="Page navigation example">
+    <nav id="pagination" aria-label="Page navigation">
         <ul class="pagination justify-content-center">
             <li class="page-item"><a class="page-link" href="#">Previous</a></li>
             <li class="page-item"><a class="page-link" href="#">1</a></li>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -86,17 +86,11 @@
         </tbody>
     </table>
 
-    <nav aria-label="Page navigation example">
+    <nav id="pagination" aria-label="Page navigation example">
         <ul class="pagination justify-content-center">
-            <li class="page-item">
-                <a class="page-link">Previous</a>
-            </li>
+            <li class="page-item"><a class="page-link" href="#">Previous</a></li>
             <li class="page-item"><a class="page-link" href="#">1</a></li>
-            <li class="page-item"><a class="page-link" href="#">2</a></li>
-            <li class="page-item"><a class="page-link" href="#">3</a></li>
-            <li class="page-item">
-                <a class="page-link" href="#">Next</a>
-            </li>
+            <li class="page-item"><a class="page-link" href="#">Next</a></li>
         </ul>
     </nav>
 

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -13,4 +13,24 @@
             </attr>
         </attr>
     </attr>
+
+    <attr sel="#pagination">
+        <attr sel="li[0]/a"
+              th:text="'previous'"
+              th:href="@{/articles(page=${articles.number - 1})}"
+              th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+        />
+        <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+            <attr sel="a"
+                  th:text="${pageNumber + 1}"
+                  th:href="@{/articles(page=${pageNumber})}"
+                  th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+            />
+        </attr>
+        <attr sel="li[2]/a"
+              th:text="'next'"
+              th:href="@{/articles(page=${articles.number + 1})}"
+              th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
+        />
+    </attr>
 </thlogic>

--- a/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
@@ -1,10 +1,10 @@
 package com.fastcampus.projectboard.controller;
 
 import com.fastcampus.projectboard.config.SecurityConfig;
-import com.fastcampus.projectboard.dto.ArticleCommentDto;
 import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
 import com.fastcampus.projectboard.dto.UserAccountDto;
 import com.fastcampus.projectboard.service.ArticleService;
+import com.fastcampus.projectboard.service.PaginationService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,15 +13,17 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -36,6 +38,7 @@ class ArticleControllerTest {
 
     //실제 컨트롤러 연결을 끊고 mocking
     @MockBean private ArticleService articleService;//생성자 주입을 지원하지 않음
+    @MockBean private PaginationService paginationService;
 
     public ArticleControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
@@ -48,14 +51,46 @@ class ArticleControllerTest {
 
         given(articleService.searchArticles(eq(null),eq(null),any(Pageable.class)))
                 .willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(),anyInt())).willReturn(List.of(0, 1,2,3,4));
         //When&Then
         mvc.perform(get("/articles"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/index"))
-                .andExpect(model().attributeExists("articles"));
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attributeExists("paginationBarNumbers"));
 //                .andExpect(model().attributeExists("searchTypes"));
         then(articleService).should().searchArticles(eq(null),eq(null),any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+    }
+
+    @DisplayName("[view][GET] 게시글 리스트 (게시판) 페이지 - 페이징, 정렬 기능")
+    @Test
+    void givenPagingAndSortingParams_whenSearchingArticlesPage_thenReturnsArticlesPage() throws Exception {
+        // Given
+        String sortName = "title";
+        String direction = "desc";
+        int pageNumber = 0;
+        int pageSize = 5;
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Order.desc(sortName)));
+        List<Integer> barNumbers = List.of(1, 2, 3, 4, 5);
+        given(articleService.searchArticles(null, null, pageable)).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages())).willReturn(barNumbers);
+
+        // When & Then
+        mvc.perform(
+                        get("/articles")
+                                .queryParam("page", String.valueOf(pageNumber))
+                                .queryParam("size", String.valueOf(pageSize))
+                                .queryParam("sort", sortName + "," + direction)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/index"))
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attribute("paginationBarNumbers", barNumbers));
+        then(articleService).should().searchArticles(null, null, pageable);
+        then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
     }
 
     @DisplayName("[view]:[GET] 게시글 상세 페이지 - 정상호출")

--- a/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
@@ -37,8 +37,10 @@ class ArticleControllerTest {
     private final MockMvc mvc;
 
     //실제 컨트롤러 연결을 끊고 mocking
-    @MockBean private ArticleService articleService;//생성자 주입을 지원하지 않음
-    @MockBean private PaginationService paginationService;
+    @MockBean
+    private ArticleService articleService;//생성자 주입을 지원하지 않음
+    @MockBean
+    private PaginationService paginationService;
 
     public ArticleControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
@@ -49,9 +51,9 @@ class ArticleControllerTest {
     public void givenNothing_whenRequestingArticlesView_thenReturnsIt() throws Exception {
         //Given
 
-        given(articleService.searchArticles(eq(null),eq(null),any(Pageable.class)))
+        given(articleService.searchArticles(eq(null), eq(null), any(Pageable.class)))
                 .willReturn(Page.empty());
-        given(paginationService.getPaginationBarNumbers(anyInt(),anyInt())).willReturn(List.of(0, 1,2,3,4));
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
         //When&Then
         mvc.perform(get("/articles"))
                 .andExpect(status().isOk())
@@ -60,7 +62,7 @@ class ArticleControllerTest {
                 .andExpect(model().attributeExists("articles"))
                 .andExpect(model().attributeExists("paginationBarNumbers"));
 //                .andExpect(model().attributeExists("searchTypes"));
-        then(articleService).should().searchArticles(eq(null),eq(null),any(Pageable.class));
+        then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
         then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
     }
 
@@ -111,6 +113,7 @@ class ArticleControllerTest {
                 .andExpect(model().attributeExists("article"))
                 .andExpect(model().attributeExists("articleComments"))
                 .andExpect(model().attribute("totalCount", totalCount));
+
         then(articleService).should().getArticle(articleId);
         then(articleService).should().getArticleCount();
     }
@@ -156,7 +159,7 @@ class ArticleControllerTest {
         );
     }
 
-    private UserAccountDto createUserAccountDto(){
+    private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 1L,
                 "twonezero",

--- a/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
@@ -93,21 +93,26 @@ class ArticleControllerTest {
         then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
     }
 
-    @DisplayName("[view]:[GET] 게시글 상세 페이지 - 정상호출")
+    @DisplayName("[view]:[GET] 게시글 페이지 - 정상호출")
     @Test
     public void givenNothing_whenRequestingArticleView_thenReturnsIt() throws Exception {
         //Given
         Long articleId = 1L;
+        long totalCount = 1L;
+
         given(articleService.getArticle(articleId))
                 .willReturn(createArticleWitheCommentsDto());
+        given(articleService.getArticleCount()).willReturn(totalCount);
         //When&Then
         mvc.perform(get("/articles/" + articleId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/detail"))
                 .andExpect(model().attributeExists("article"))
-                .andExpect(model().attributeExists("articleComments"));
+                .andExpect(model().attributeExists("articleComments"))
+                .andExpect(model().attribute("totalCount", totalCount));
         then(articleService).should().getArticle(articleId);
+        then(articleService).should().getArticleCount();
     }
 
     @Disabled("구현 중")

--- a/src/test/java/com/fastcampus/projectboard/controller/AuthControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/AuthControllerTest.java
@@ -9,13 +9,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View 컨트롤러 - 인증")
 @Import(SecurityConfig.class)
-@WebMvcTest
+@WebMvcTest(Void.class)
 public class AuthControllerTest {
 
     private final MockMvc mvc;
@@ -32,6 +33,7 @@ public class AuthControllerTest {
         //When&Then
         mvc.perform(get("/login"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andDo(MockMvcResultHandlers.print());
     }
 }

--- a/src/test/java/com/fastcampus/projectboard/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/ArticleCommentServiceTest.java
@@ -7,6 +7,7 @@ import com.fastcampus.projectboard.dto.ArticleCommentDto;
 import com.fastcampus.projectboard.dto.UserAccountDto;
 import com.fastcampus.projectboard.repository.ArticleCommentRepository;
 import com.fastcampus.projectboard.repository.ArticleRepository;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 
 @DisplayName("비즈니스 로직 - 댓글")
+@Disabled("구현 중")
 @ExtendWith(MockitoExtension.class)
 class ArticleCommentServiceTest {
     @InjectMocks

--- a/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
@@ -162,6 +162,20 @@ class ArticleServiceTest {
         then(articleRepository).should().deleteById(articleId);
     }
 
+    @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다")
+    @Test
+    void givenNothing_whenCountingArticles_thenReturnsArticleCount() {
+        // Given
+        long expected = 0L;
+        given(articleRepository.count()).willReturn(expected);
+
+        // When
+        long actual = sut.getArticleCount();
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+        then(articleRepository).should().count();
+    }
 
     private UserAccount createUserAccount() {
         return UserAccount.of(

--- a/src/test/java/com/fastcampus/projectboard/service/PaginationServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/PaginationServiceTest.java
@@ -1,0 +1,67 @@
+package com.fastcampus.projectboard.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+
+@DisplayName("비즈니스 로직 - 페이지네이션")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = PaginationService.class)
+class PaginationServiceTest {
+
+    //    private final PaginationService sut = new PaginationService();
+    private final PaginationService sut;
+
+    public PaginationServiceTest(@Autowired PaginationService paginationService) {
+        this.sut = paginationService;
+    }
+
+    static Stream<Arguments> givenCurPageAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers() {
+        //Spring data 에서 주는 Page 는 index 0부터 시작함
+        return Stream.of(
+                arguments(0, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(1, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(2, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(3, 13, List.of(1, 2, 3, 4, 5)),
+                arguments(4, 13, List.of(2, 3, 4, 5, 6)),
+                arguments(5, 13, List.of(3, 4, 5, 6, 7)),
+                arguments(6, 13, List.of(4, 5, 6, 7, 8)),
+                arguments(10, 13, List.of(8, 9, 10, 11, 12)),
+                arguments(11, 13, List.of(9, 10, 11 ,12)),
+                arguments(12, 13, List.of(10, 11 ,12))
+                );
+    }
+
+    @DisplayName("현재 페이지 번호와 총 페이지 수를 주면, 페이징 바 리스트를 반환")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] {0},{1} => {2}")
+    void givenCurPageAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers(int curPageNumber, int totalPages, List<Integer> expected) {
+        //Given
+
+        //When
+        List<Integer> actual = sut.getPaginationBarNumbers(curPageNumber, totalPages);
+        //Then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @DisplayName("현재 설정되어 있는 페이지네이션 바의 길이를 반환")
+    @Test
+    void givenNothing_whenCalled_thenReturnsCurBarLength() {
+        //Given
+
+        //When
+        int barLength = sut.curBarLength();
+        //Then
+        assertThat(barLength).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
게시판과 게시글에 페이징 기능을 구현

Spring data 의 Page 라이브러리를 이용해 쉽고 빠르게 페이지네이션을 구현할 수 있었다.

Page 에서 주는 feature 중에 현재 페이지와 총 페이지 등을 계산하여 페이지 리스트 바를 생성하고
뷰 템플릿에 적절한 스타일링과 함께 적용하였다.

This closes #27 